### PR TITLE
Install the latest version (v0.5) of git-buildkite

### DIFF
--- a/git-buildkite.rb
+++ b/git-buildkite.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class GitBuildkite < Formula
   homepage "https://github.com/sj26/git-buildkite"
-  url "https://github.com/sj26/git-buildkite/archive/v0.4.2.tar.gz"
+  url "https://github.com/sj26/git-buildkite/archive/v0.5.tar.gz"
   head "https://github.com/sj26/git-buildkite.git"
 
   def install


### PR DESCRIPTION
Hi,

The latest version of `git-buildkite` is `v0.5` while this Homebrew formula installs `v0.4.2`.

This PR updates it to `v0.5`.

Thanks. 😄 